### PR TITLE
Add database listing page and tests

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -3,8 +3,11 @@ const path = require('path');
 
 let db;
 
-function initDB() {
-  const dbPath = path.join(__dirname, '..', 'database.db');
+function initDB(customPath) {
+  const dbPath =
+    customPath ||
+    process.env.DATABASE_PATH ||
+    path.join(__dirname, '..', 'database.db');
   db = new sqlite3.Database(dbPath);
   db.serialize(() => {
     db.run(`CREATE TABLE IF NOT EXISTS articles (
@@ -43,4 +46,11 @@ function getArticles() {
   });
 }
 
-module.exports = { initDB, saveArticle, getArticles };
+function closeDB() {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+module.exports = { initDB, saveArticle, getArticles, closeDB };

--- a/src/server.js
+++ b/src/server.js
@@ -11,6 +11,10 @@ const mainTemplate = fs.readFileSync(
     path.join(__dirname, 'templates', 'main.html'),
     'utf8',
 );
+const databaseTemplate = fs.readFileSync(
+    path.join(__dirname, 'templates', 'database.html'),
+    'utf8',
+);
 
 function stringToColor(str) {
     let hash = 0;
@@ -36,6 +40,25 @@ function createServer() {
                 .then((rows) => {
                     res.writeHead(200, { 'Content-Type': 'application/json' });
                     res.end(JSON.stringify(rows));
+                })
+                .catch(() => {
+                    res.writeHead(500, { 'Content-Type': 'text/plain' });
+                    res.end('Error retrieving articles');
+                });
+            return;
+        }
+        if (urlObj.pathname === '/database') {
+            getArticles()
+                .then((rows) => {
+                    const rowsHtml = rows
+                        .map(
+                            (r) =>
+                                `<tr><td class="border px-2 py-1">${r.id}</td><td class="border px-2 py-1"><a href="${r.link}" target="_blank">${r.title}</a></td><td class="border px-2 py-1">${r.link}</td></tr>`,
+                        )
+                        .join('');
+                    const html = databaseTemplate.replace('{{rows}}', rowsHtml);
+                    res.writeHead(200, { 'Content-Type': 'text/html' });
+                    res.end(html);
                 })
                 .catch(() => {
                     res.writeHead(500, { 'Content-Type': 'text/plain' });

--- a/src/templates/database.html
+++ b/src/templates/database.html
@@ -1,0 +1,20 @@
+<html>
+<head>
+    <title>Database</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="font-sans p-5">
+    <nav class="mb-4 space-x-4">
+        <a href="/" class="text-blue-600">Home</a>
+        <a href="/database" class="text-blue-600">Database</a>
+    </nav>
+    <table class="min-w-full border-collapse">
+        <tr>
+            <th class="border px-2 py-1">ID</th>
+            <th class="border px-2 py-1">Title</th>
+            <th class="border px-2 py-1">Link</th>
+        </tr>
+        {{rows}}
+    </table>
+</body>
+</html>

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -47,6 +47,10 @@ function addFeed() {
     </script>
 </head>
 <body class="font-sans p-5">
+    <nav class="mb-4 space-x-4">
+        <a href="/" class="text-blue-600">Home</a>
+        <a href="/database" class="text-blue-600">Database</a>
+    </nav>
     {{formHtml}}
     {{sections}}
 </body>

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -1,0 +1,19 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const { initDB, saveArticle, getArticles, closeDB } = require('../src/db');
+
+test('saveArticle and getArticles round trip', async () => {
+    const tmpPath = path.join(os.tmpdir(), `dbtest_${Date.now()}.sqlite`);
+    initDB(tmpPath);
+    await saveArticle('Example', 'http://example.com');
+    const rows = await getArticles();
+    assert.equal(rows.length, 1);
+    assert.equal(rows[0].title, 'Example');
+    assert.equal(rows[0].link, 'http://example.com');
+    closeDB();
+    fs.unlinkSync(tmpPath);
+});


### PR DESCRIPTION
## Summary
- add configurable database path and close helper
- add `/database` page with nav menu
- create HTML template for DB page and add nav to main page
- include unit test for DB functions

## Testing
- `npm test`