### PR TITLE
Implement published date storage and set experiment as home

### DIFF
--- a/src/db.js
+++ b/src/db.js
@@ -15,20 +15,21 @@ function initDB(customPath) {
       title TEXT NOT NULL,
       link TEXT NOT NULL UNIQUE,
       embedding TEXT,
-      image TEXT
+      image TEXT,
+      published TEXT
     )`);
   });
 }
 
-function saveArticle(title, link, embedding, image) {
+function saveArticle(title, link, embedding, image, published) {
   return new Promise((resolve, reject) => {
     if (!db) {
       return reject(new Error('Database not initialized'));
     }
     const embStr = embedding ? JSON.stringify(embedding) : null;
     db.run(
-      'INSERT OR IGNORE INTO articles (title, link, embedding, image) VALUES (?, ?, ?, ?)',
-      [title, link, embStr, image || null],
+      'INSERT OR IGNORE INTO articles (title, link, embedding, image, published) VALUES (?, ?, ?, ?, ?)',
+      [title, link, embStr, image || null, published || new Date().toISOString()],
       function (err) {
         if (err) reject(err);
         else resolve(this.lastID);
@@ -43,7 +44,7 @@ function getArticleByLink(link) {
       return reject(new Error('Database not initialized'));
     }
     db.get(
-      'SELECT id, title, link, embedding, image FROM articles WHERE link = ?',
+      'SELECT id, title, link, embedding, image, published FROM articles WHERE link = ?',
       [link],
       (err, row) => {
         if (err) reject(err);
@@ -58,7 +59,7 @@ function getArticles() {
     if (!db) {
       return reject(new Error('Database not initialized'));
     }
-    db.all('SELECT id, title, link, embedding, image FROM articles', (err, rows) => {
+    db.all('SELECT id, title, link, embedding, image, published FROM articles', (err, rows) => {
       if (err) reject(err);
       else resolve(rows);
     });

--- a/src/templates/database.html
+++ b/src/templates/database.html
@@ -17,6 +17,7 @@
                 <th class="border px-2 py-1">Image</th>
                 <th class="border px-2 py-1">Title</th>
                 <th class="border px-2 py-1">Link</th>
+                <th class="border px-2 py-1">Published</th>
                 <th class="border px-2 py-1">Embedding</th>
             </tr>
         </thead>

--- a/tests/db.test.js
+++ b/tests/db.test.js
@@ -17,7 +17,8 @@ test('saveArticle and getArticles round trip with embedding and image', async ()
     const tmpPath = path.join(os.tmpdir(), `dbtest_${Date.now()}.sqlite`);
     initDB(tmpPath);
     const emb = [0.1, 0.2, 0.3];
-    await saveArticle('Example', 'http://example.com', emb, 'http://img.com/img.jpg');
+    const pub = '2020-01-01T00:00:00.000Z';
+    await saveArticle('Example', 'http://example.com', emb, 'http://img.com/img.jpg', pub);
 
     const rows = await getArticles();
     assert.equal(rows.length, 1);
@@ -26,9 +27,11 @@ test('saveArticle and getArticles round trip with embedding and image', async ()
 
     assert.deepEqual(JSON.parse(rows[0].embedding), emb);
     assert.equal(rows[0].image, 'http://img.com/img.jpg');
+    assert.equal(rows[0].published, pub);
     const row = await getArticleByLink('http://example.com');
     assert.deepEqual(JSON.parse(row.embedding), emb);
     assert.equal(row.image, 'http://img.com/img.jpg');
+    assert.equal(row.published, pub);
 
     closeDB();
     fs.unlinkSync(tmpPath);


### PR DESCRIPTION
## Summary
- add `published` column for articles and store values
- update `/database` page to show published date
- set the Experiment page as the home page
- adjust DB tests for new column

## Testing
- `npm test`