### PR TITLE
Add threshold and keyword filtering to experiment page

### DIFF
--- a/src/templates/experiment.html
+++ b/src/templates/experiment.html
@@ -9,9 +9,16 @@
         <a href="/database" class="text-blue-600">Database</a>
         <a href="/experiment" class="text-blue-600">Experiment</a>
     </nav>
-    <div class="mb-4">
+    <div class="mb-4 space-y-2">
+        <input id="rssFeed" class="border p-2 w-full" type="text" placeholder="RSS Feed URL" />
         <textarea id="queryText" class="border p-2 w-full" rows="3" placeholder="Enter text"></textarea>
-        <button id="runBtn" class="bg-blue-500 text-white px-4 py-2 mt-2 rounded">Run</button>
+        <input id="keywordsInput" class="border p-2 w-full" type="text" placeholder="Keywords (comma separated)" />
+        <div class="flex items-center space-x-2">
+            <label for="thresholdInput">Threshold:</label>
+            <input id="thresholdInput" class="border p-1" type="number" min="0" max="1" step="0.01" value="0.8" />
+            <button id="loadBtn" class="bg-blue-500 text-white px-4 py-2 rounded">Load</button>
+        </div>
+        <div id="counts" class="text-sm text-gray-600"></div>
     </div>
     <table id="resultsTable" class="min-w-full border-collapse">
         <thead>
@@ -19,6 +26,7 @@
                 <th class="border px-2 py-1">ID</th>
                 <th class="border px-2 py-1">Title</th>
                 <th class="border px-2 py-1">Similarity</th>
+                <th class="border px-2 py-1">Keyword Match</th>
             </tr>
         </thead>
         <tbody>
@@ -28,17 +36,25 @@
         function loadResults(text) {
             const url = new URL('/experiment/search', window.location.origin);
             if (text) url.searchParams.set('text', text);
+            const feed = document.getElementById('rssFeed').value;
+            if (feed) url.searchParams.set('feed', feed);
+            const kw = document.getElementById('keywordsInput').value;
+            if (kw) url.searchParams.set('keywords', kw);
+            const threshold = document.getElementById('thresholdInput').value;
+            if (threshold) url.searchParams.set('threshold', threshold);
             fetch(url)
                 .then(r => r.json())
-                .then(rows => {
+                .then(data => {
                     const tbody = document.querySelector('#resultsTable tbody');
-                    tbody.innerHTML = rows.map(row => {
+                    tbody.innerHTML = data.results.map(row => {
                         const sim = row.similarity === null || row.similarity === undefined ? '' : row.similarity.toFixed(2);
-                        return `<tr><td class="border px-2 py-1">${row.id}</td><td class="border px-2 py-1"><a href="${row.link}" target="_blank">${row.title}</a></td><td class="border px-2 py-1">${sim}</td></tr>`;
+                        const match = row.match ? 'Yes' : 'No';
+                        return `<tr><td class="border px-2 py-1">${row.id}</td><td class="border px-2 py-1"><a href="${row.link}" target="_blank">${row.title}</a></td><td class="border px-2 py-1">${sim}</td><td class="border px-2 py-1">${match}</td></tr>`;
                     }).join('');
+                    document.getElementById('counts').innerText = `${data.filtered} of ${data.total} articles shown`;
                 });
         }
-        document.getElementById('runBtn').addEventListener('click', () => {
+        document.getElementById('loadBtn').addEventListener('click', () => {
             const text = document.getElementById('queryText').value;
             loadResults(text);
         });


### PR DESCRIPTION
## Summary
- extend the experiment search endpoint to optionally load a feed, filter by a threshold and flag keyword matches
- augment experiment page with inputs for RSS feed, keywords and threshold
- show counts of loaded vs filtered articles and display keyword match column

## Testing
- `npm test`