### PR TITLE
Handle invalid entities in RSS feeds

### DIFF
--- a/src/rss.js
+++ b/src/rss.js
@@ -7,7 +7,9 @@ async function fetchRSS(url) {
     }
     const data = await response.text();
     return new Promise((resolve, reject) => {
-        parseString(data, (err, result) => {
+        // Some feeds include unescaped characters like '&'.
+        // Use non-strict parsing so xml2js can handle them.
+        parseString(data, { strict: false }, (err, result) => {
             if (err) {
                 reject(err);
                 return;

--- a/src/templates/experiment.html
+++ b/src/templates/experiment.html
@@ -12,6 +12,7 @@
     <div class="mb-4 space-y-2">
         <textarea id="queryText" class="border p-2 w-full" rows="3" placeholder="Enter text"></textarea>
         <input id="keywordsInput" class="border p-2 w-full" type="text" placeholder="Keywords (comma separated)" />
+        <input id="feedInput" class="border p-2 w-full" type="text" placeholder="RSS feed URL (leave blank for database)" />
         <div class="flex items-center space-x-2">
             <label for="thresholdInput">Threshold:</label>
             <input id="thresholdInput" class="border p-1" type="number" min="0" max="1" step="0.01" value="0.8" />
@@ -37,6 +38,8 @@
             if (text) url.searchParams.set('text', text);
             const kw = document.getElementById('keywordsInput').value;
             if (kw) url.searchParams.set('keywords', kw);
+            const feed = document.getElementById('feedInput').value;
+            if (feed) url.searchParams.set('feed', feed);
             const threshold = document.getElementById('thresholdInput').value;
             if (threshold) url.searchParams.set('threshold', threshold);
             fetch(url)

--- a/tests/rss.test.js
+++ b/tests/rss.test.js
@@ -27,3 +27,28 @@ test('fetchRSS parses RSS feed from HTTP server', async () => {
         server.close();
     }
 });
+
+const xmlInvalid = `<?xml version="1.0" encoding="UTF-8"?>
+<rss version="2.0">
+  <channel>
+    <title>Sample Feed</title>
+    <item><title>Hello & goodbye</title></item>
+  </channel>
+</rss>`;
+
+test('fetchRSS tolerates unescaped ampersands', async () => {
+    const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'application/xml' });
+        res.end(xmlInvalid);
+    });
+
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+
+    try {
+        const result = await fetchRSS(`http://localhost:${port}/`);
+        assert.equal(result.rss.channel[0].item[0].title[0], 'Hello & goodbye');
+    } finally {
+        server.close();
+    }
+});


### PR DESCRIPTION
## Summary
- relax XML parsing to ignore invalid entities
- test fetchRSS with an unescaped ampersand

## Testing
- `npm test` *(fails: Cannot find module 'sqlite3')*