### PR TITLE
Add filter modules and tests

### DIFF
--- a/src/filters/filterManager.js
+++ b/src/filters/filterManager.js
@@ -1,0 +1,42 @@
+const { keywordFilter } = require('./keywordFilter');
+const { semanticFilter } = require('./semanticFilter');
+
+class FilterManager {
+    constructor(options = {}) {
+        this.keywords = options.keywords || [];
+        this.queryEmbedding = options.queryEmbedding || null;
+        this.threshold = typeof options.threshold === 'number' ? options.threshold : 0;
+    }
+
+    static async load(options = {}) {
+        // Placeholder for loading from DB in future
+        return new FilterManager(options);
+    }
+
+    apply(article) {
+        const reasons = [];
+        let similarity = null;
+        if (this.queryEmbedding) {
+            const emb = Array.isArray(article.embedding)
+                ? article.embedding
+                : article.embedding
+                ? JSON.parse(article.embedding)
+                : null;
+            const result = semanticFilter(emb, this.queryEmbedding);
+            similarity = result.similarity;
+            if (similarity !== null && similarity >= this.threshold) {
+                reasons.push(`similarity ${similarity.toFixed(2)} >= ${this.threshold}`);
+            }
+        }
+        if (this.keywords.length > 0) {
+            const text = article.title || '';
+            const { matched, hits } = keywordFilter(text, this.keywords);
+            if (matched) {
+                reasons.push(`keywords: ${hits.join(', ')}`);
+            }
+        }
+        return { reasons, similarity };
+    }
+}
+
+module.exports = { FilterManager };

--- a/src/filters/keywordFilter.js
+++ b/src/filters/keywordFilter.js
@@ -1,0 +1,8 @@
+function keywordFilter(text, keywords = []) {
+    if (!text) return { matched: false, hits: [] };
+    const lower = text.toLowerCase();
+    const hits = keywords.filter((k) => lower.includes(k.toLowerCase()));
+    return { matched: hits.length > 0, hits };
+}
+
+module.exports = { keywordFilter };

--- a/src/filters/semanticFilter.js
+++ b/src/filters/semanticFilter.js
@@ -1,0 +1,11 @@
+const { cosineSimilarity } = require('../similarity');
+
+function semanticFilter(articleEmbedding, queryEmbedding) {
+    if (!articleEmbedding || !queryEmbedding) {
+        return { similarity: null };
+    }
+    const similarity = cosineSimilarity(articleEmbedding, queryEmbedding);
+    return { similarity };
+}
+
+module.exports = { semanticFilter };

--- a/tests/filterManager.test.js
+++ b/tests/filterManager.test.js
@@ -1,0 +1,19 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { FilterManager } = require('../src/filters/filterManager');
+
+test('FilterManager applies keyword and semantic filters', () => {
+    const manager = new FilterManager({
+        keywords: ['foo'],
+        queryEmbedding: [1, 0],
+        threshold: 0.5,
+    });
+
+    const article = { title: 'Foo bar', embedding: [1, 0] };
+    const result = manager.apply(article);
+    assert.ok(result.reasons.some((r) => r.includes('keywords')));
+    assert.ok(result.reasons.some((r) => r.includes('similarity')));
+    assert.equal(result.similarity, 1);
+});
+
+

--- a/tests/keywordFilter.test.js
+++ b/tests/keywordFilter.test.js
@@ -1,0 +1,11 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { keywordFilter } = require('../src/filters/keywordFilter');
+
+test('keywordFilter finds keywords case-insensitively', () => {
+    const { matched, hits } = keywordFilter('Hello World', ['world', 'foo']);
+    assert.equal(matched, true);
+    assert.deepEqual(hits, ['world']);
+});
+
+

--- a/tests/semanticFilter.test.js
+++ b/tests/semanticFilter.test.js
@@ -1,0 +1,15 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const { semanticFilter } = require('../src/filters/semanticFilter');
+
+test('semanticFilter returns similarity value', () => {
+    const { similarity } = semanticFilter([1, 0], [1, 0]);
+    assert.equal(similarity, 1);
+});
+
+test('semanticFilter handles missing embeddings', () => {
+    const { similarity } = semanticFilter(null, [1, 2]);
+    assert.equal(similarity, null);
+});
+
+


### PR DESCRIPTION
## Summary
- add `keywordFilter` and `semanticFilter` under `src/filters`
- implement `FilterManager` that applies these filters
- refactor `/experiment/search` route to use `FilterManager`
- test new filters and manager

## Testing
- `npm test --silent`