### PR TITLE
Add table view for scraped links

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -1,0 +1,46 @@
+const { URL } = require('url');
+const builder = require('xmlbuilder');
+
+async function scrapeLinks(targetUrl) {
+    const res = await fetch(targetUrl);
+    if (!res.ok) {
+        throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
+    }
+    const html = await res.text();
+
+    const anchorRegex = /<a\s+[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/gi;
+    const seen = new Set();
+    const items = [];
+    let match;
+    while ((match = anchorRegex.exec(html))) {
+        const link = new URL(match[1], targetUrl).href;
+        const text = match[2].replace(/<[^>]*>/g, '').trim();
+        if (!text || seen.has(link)) continue;
+        seen.add(link);
+        items.push({ title: text, link });
+        if (items.length >= 10) break;
+    }
+    return items;
+}
+
+async function scrapeToRSS(targetUrl) {
+    const items = await scrapeLinks(targetUrl);
+
+    const rss = builder
+        .create('rss', { version: '1.0', encoding: 'UTF-8' })
+        .att('version', '2.0');
+    const channel = rss.ele('channel');
+    channel.ele('title', targetUrl);
+    channel.ele('link', targetUrl);
+    channel.ele('description', `Generated feed for ${targetUrl}`);
+
+    for (const item of items) {
+        const it = channel.ele('item');
+        it.ele('title', item.title);
+        it.ele('link', item.link);
+    }
+
+    return rss.end({ pretty: true });
+}
+
+module.exports = { scrapeToRSS, scrapeLinks };

--- a/src/templates/database.html
+++ b/src/templates/database.html
@@ -8,6 +8,7 @@
         <a href="/" class="text-blue-600">Home</a>
         <a href="/database" class="text-blue-600">Database</a>
         <a href="/experiment" class="text-blue-600">Experiment</a>
+        <a href="/scrape" class="text-blue-600">Scraper</a>
     </nav>
     <input id="searchInput" type="text" placeholder="Search" class="border p-2 mb-4 w-full" oninput="filterRows()" />
     <table id="articlesTable" class="min-w-full border-collapse">

--- a/src/templates/experiment.html
+++ b/src/templates/experiment.html
@@ -8,6 +8,7 @@
         <a href="/" class="text-blue-600">Home</a>
         <a href="/database" class="text-blue-600">Database</a>
         <a href="/experiment" class="text-blue-600">Experiment</a>
+        <a href="/scrape" class="text-blue-600">Scraper</a>
     </nav>
     <div class="mb-4 space-y-2">
         <textarea id="queryText" class="border p-2 w-full" rows="3" placeholder="Enter text"></textarea>

--- a/src/templates/main.html
+++ b/src/templates/main.html
@@ -51,6 +51,7 @@ function addFeed() {
         <a href="/" class="text-blue-600">Home</a>
         <a href="/database" class="text-blue-600">Database</a>
         <a href="/experiment" class="text-blue-600">Experiment</a>
+        <a href="/scrape" class="text-blue-600">Scraper</a>
     </nav>
     {{formHtml}}
     {{sections}}

--- a/src/templates/scraper.html
+++ b/src/templates/scraper.html
@@ -1,0 +1,19 @@
+<html>
+<head>
+    <title>RSS Scraper</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="font-sans p-5">
+    <nav class="mb-4 space-x-4">
+        <a href="/" class="text-blue-600">Home</a>
+        <a href="/database" class="text-blue-600">Database</a>
+        <a href="/experiment" class="text-blue-600">Experiment</a>
+        <a href="/scrape" class="text-blue-600">Scraper</a>
+    </nav>
+    <form>
+        <input type="text" name="url" value="{{url}}" class="border p-2 mr-2 w-80" placeholder="Website URL" />
+        <button type="submit" class="bg-blue-500 text-white px-4 py-2">Scrape</button>
+    </form>
+    {{table}}
+</body>
+</html>

--- a/tests/scraper.test.js
+++ b/tests/scraper.test.js
@@ -1,0 +1,56 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const http = require('http');
+const { parseString } = require('xml2js');
+const { scrapeToRSS, scrapeLinks } = require('../src/scraper');
+
+const html = `
+<html><body>
+    <a href="/a1">First</a>
+    <a href="/a2">Second</a>
+</body></html>`;
+
+test('scrapeToRSS builds rss feed from html page', async () => {
+    const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(html);
+    });
+
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+
+    try {
+        const xml = await scrapeToRSS(`http://localhost:${port}/`);
+        await new Promise((resolve, reject) => {
+            parseString(xml, (err, result) => {
+                if (err) return reject(err);
+                const items = result.rss.channel[0].item;
+                assert.equal(items.length, 2);
+                assert.equal(items[0].title[0], 'First');
+                assert.equal(items[0].link[0], `http://localhost:${port}/a1`);
+                resolve();
+            });
+        });
+    } finally {
+        server.close();
+    }
+});
+
+test('scrapeLinks extracts titles and absolute links', async () => {
+    const server = http.createServer((req, res) => {
+        res.writeHead(200, { 'Content-Type': 'text/html' });
+        res.end(html);
+    });
+
+    await new Promise((resolve) => server.listen(0, resolve));
+    const port = server.address().port;
+
+    try {
+        const items = await scrapeLinks(`http://localhost:${port}/`);
+        assert.equal(items.length, 2);
+        assert.equal(items[0].title, 'First');
+        assert.equal(items[0].link, `http://localhost:${port}/a1`);
+    } finally {
+        server.close();
+    }
+});


### PR DESCRIPTION
## Summary
- extend scraper utility with a `scrapeLinks` helper
- show scraped links as a table on `/scrape`
- keep RSS generation via `scrapeToRSS`
- adjust scraper template and tests

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683a0f2fcbe883319de28f661e9fe56d