### PR TITLE
Show scraped RSS items in table

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -1,7 +1,7 @@
 const { URL } = require('url');
 const builder = require('xmlbuilder');
 
-async function scrapeToRSS(targetUrl) {
+async function scrapeItems(targetUrl) {
     const res = await fetch(targetUrl);
     if (!res.ok) {
         throw new Error(`Failed to fetch: ${res.status} ${res.statusText}`);
@@ -20,7 +20,10 @@ async function scrapeToRSS(targetUrl) {
         items.push({ title: text, link });
         if (items.length >= 10) break;
     }
+    return items;
+}
 
+function buildRSS(targetUrl, items) {
     const rss = builder
         .create('rss', { version: '1.0', encoding: 'UTF-8' })
         .att('version', '2.0');
@@ -38,4 +41,9 @@ async function scrapeToRSS(targetUrl) {
     return rss.end({ pretty: true });
 }
 
-module.exports = { scrapeToRSS };
+async function scrapeToRSS(targetUrl) {
+    const items = await scrapeItems(targetUrl);
+    return buildRSS(targetUrl, items);
+}
+
+module.exports = { scrapeToRSS, scrapeItems, buildRSS };

--- a/src/templates/scraper.html
+++ b/src/templates/scraper.html
@@ -14,5 +14,17 @@
         <input type="text" name="url" class="border p-2 mr-2 w-80" placeholder="Website URL" />
         <button type="submit" class="bg-blue-500 text-white px-4 py-2">Generate RSS</button>
     </form>
+    <table class="min-w-full border-collapse mt-4">
+        <thead>
+            <tr>
+                <th class="border px-2 py-1">#</th>
+                <th class="border px-2 py-1">Title</th>
+                <th class="border px-2 py-1">Link</th>
+            </tr>
+        </thead>
+        <tbody>
+            {{rows}}
+        </tbody>
+    </table>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- refactor scraper to allow returning parsed items
- update scraper HTML template with table placeholder
- show scraped articles in a table on `/scrape`

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683a1644f4288331bcc7a4e5549c883a