### PR TITLE
Add prnewswire scraping support

### DIFF
--- a/src/server.js
+++ b/src/server.js
@@ -63,31 +63,30 @@ function createServer() {
             return;
         }
         if (urlObj.pathname === '/scrape') {
-            const siteUrl = urlObj.searchParams.get('url');
-            if (!siteUrl) {
-                res.writeHead(200, { 'Content-Type': 'text/html' });
-                const html = scraperTemplate.replace('{{rows}}', '');
-                res.end(html);
-            } else {
-                scrapeItems(siteUrl)
-                    .then((items) => {
-                        const rows = items
-                            .map(
-                                (it, i) =>
-                                    `<tr><td class="border px-2 py-1">${
-                                        i + 1
-                                    }</td><td class="border px-2 py-1">${it.title}</td><td class="border px-2 py-1"><a href="${it.link}" target="_blank">${it.link}</a></td></tr>`,
-                            )
-                            .join('');
-                        const html = scraperTemplate.replace('{{rows}}', rows);
-                        res.writeHead(200, { 'Content-Type': 'text/html' });
-                        res.end(html);
-                    })
-                    .catch((err) => {
-                        res.writeHead(500, { 'Content-Type': 'text/plain' });
-                        res.end('Error scraping site: ' + err.message);
-                    });
-            }
+            const defaultUrl =
+                'https://www.prnewswire.com/news-releases/financial-services-latest-news/acquisitions-mergers-and-takeovers-list/';
+            const siteUrl = urlObj.searchParams.get('url') || defaultUrl;
+
+            scrapeItems(siteUrl)
+                .then((items) => {
+                    const rows = items
+                        .map(
+                            (it, i) =>
+                                `<tr><td class="border px-2 py-1">${
+                                    i + 1
+                                }</td><td class="border px-2 py-1">${it.title}</td><td class="border px-2 py-1">${it.description || ''}</td><td class="border px-2 py-1"><a href="${it.link}" target="_blank">${it.link}</a></td></tr>`,
+                        )
+                        .join('');
+                    const html = scraperTemplate
+                        .replace('{{rows}}', rows)
+                        .replace('{{url}}', siteUrl);
+                    res.writeHead(200, { 'Content-Type': 'text/html' });
+                    res.end(html);
+                })
+                .catch((err) => {
+                    res.writeHead(500, { 'Content-Type': 'text/plain' });
+                    res.end('Error scraping site: ' + err.message);
+                });
             return;
         }
         if (urlObj.pathname === '/database') {

--- a/src/templates/scraper.html
+++ b/src/templates/scraper.html
@@ -11,7 +11,7 @@
         <a href="/scrape" class="text-blue-600">Scraper</a>
     </nav>
     <form>
-        <input type="text" name="url" class="border p-2 mr-2 w-80" placeholder="Website URL" />
+        <input type="text" name="url" class="border p-2 mr-2 w-80" placeholder="Website URL" value="{{url}}" />
         <button type="submit" class="bg-blue-500 text-white px-4 py-2">Generate RSS</button>
     </form>
     <table class="min-w-full border-collapse mt-4">
@@ -19,6 +19,7 @@
             <tr>
                 <th class="border px-2 py-1">#</th>
                 <th class="border px-2 py-1">Title</th>
+                <th class="border px-2 py-1">Description</th>
                 <th class="border px-2 py-1">Link</th>
             </tr>
         </thead>

--- a/tests/scraper.test.js
+++ b/tests/scraper.test.js
@@ -3,6 +3,7 @@ const assert = require('node:assert/strict');
 const http = require('http');
 const { parseString } = require('xml2js');
 const { scrapeToRSS } = require('../src/scraper');
+const { parsePrnewswire } = require('../src/scraper');
 
 const html = `
 <html><body>
@@ -34,4 +35,28 @@ test('scrapeToRSS builds rss feed from html page', async () => {
     } finally {
         server.close();
     }
+});
+
+test('parsePrnewswire extracts articles', () => {
+    const snippet = `
+    <div class="row newsCards" lang="en-US">
+        <div class="col-sm-12 card">
+            <a class="newsreleaseconsolidatelink display-outline w-100" href="/news-releases/hotel101-progresses-towards-nasdaq-listing-302470771.html" role="group" aria-label="News Release">
+    <h3 class="no-top-margin remove-outline">
+        <small>10:10 ET</small>
+        HOTEL101 PROGRESSES TOWARDS NASDAQ LISTING
+    </h3>
+            <p class="remove-outline">Hotel101 Global Holdings Corp. ("Hotel101" or "HBNB") and JVSPAC Acquisition Corp. (NASDAQ: JVSA) ("JVSPAC") announced today that the United States...</p>
+            </a>
+        </div>
+    </div>`;
+
+    const items = parsePrnewswire(snippet, 'https://www.prnewswire.com/');
+    assert.equal(items.length, 1);
+    assert.equal(items[0].title, 'HOTEL101 PROGRESSES TOWARDS NASDAQ LISTING');
+    assert.ok(items[0].description.startsWith('Hotel101 Global'));
+    assert.equal(
+        items[0].link,
+        'https://www.prnewswire.com/news-releases/hotel101-progresses-towards-nasdaq-listing-302470771.html',
+    );
 });


### PR DESCRIPTION
## Summary
- expand scraper to support prnewswire.com pages
- expose `parsePrnewswire` for tests
- show descriptions in scraper table and default to PR Newswire url
- test prnewswire parsing

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dbbc3cc888331bf8965f2952d8692