### PR TITLE
Add scraped articles database and show rules

### DIFF
--- a/src/scrapedDb.js
+++ b/src/scrapedDb.js
@@ -1,0 +1,67 @@
+const sqlite3 = require('sqlite3').verbose();
+const path = require('path');
+
+let db;
+
+function initScrapedDB(customPath) {
+  const dbPath =
+    customPath ||
+    process.env.SCRAPED_DB_PATH ||
+    path.join(__dirname, '..', 'scraped.db');
+  db = new sqlite3.Database(dbPath);
+  db.serialize(() => {
+    db.run(`CREATE TABLE IF NOT EXISTS scraped_articles (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      url TEXT NOT NULL,
+      title TEXT,
+      description TEXT,
+      link TEXT,
+      published TEXT
+    )`);
+  });
+}
+
+function saveScrapedArticle(url, title, description, link, published) {
+  return new Promise((resolve, reject) => {
+    if (!db) {
+      return reject(new Error('Database not initialized'));
+    }
+    db.run(
+      'INSERT INTO scraped_articles (url, title, description, link, published) VALUES (?, ?, ?, ?, ?)',
+      [url, title, description, link, published || null],
+      function (err) {
+        if (err) reject(err);
+        else resolve(this.lastID);
+      },
+    );
+  });
+}
+
+function getScrapedArticles() {
+  return new Promise((resolve, reject) => {
+    if (!db) {
+      return reject(new Error('Database not initialized'));
+    }
+    db.all(
+      'SELECT id, url, title, description, link, published FROM scraped_articles',
+      (err, rows) => {
+        if (err) reject(err);
+        else resolve(rows);
+      },
+    );
+  });
+}
+
+function closeScrapedDB() {
+  if (db) {
+    db.close();
+    db = null;
+  }
+}
+
+module.exports = {
+  initScrapedDB,
+  saveScrapedArticle,
+  getScrapedArticles,
+  closeScrapedDB,
+};

--- a/src/templates/scraper.html
+++ b/src/templates/scraper.html
@@ -14,6 +14,12 @@
         <input type="text" name="url" class="border p-2 mr-2 w-80" placeholder="Website URL" value="{{url}}" />
         <button type="submit" class="bg-blue-500 text-white px-4 py-2">Generate RSS</button>
     </form>
+    <div class="mt-4">
+        <p><strong>URL:</strong> {{url}}</p>
+        <ul class="list-disc pl-5">
+            {{rules}}
+        </ul>
+    </div>
     <table class="min-w-full border-collapse mt-4">
         <thead>
             <tr>
@@ -21,6 +27,7 @@
                 <th class="border px-2 py-1">Title</th>
                 <th class="border px-2 py-1">Description</th>
                 <th class="border px-2 py-1">Link</th>
+                <th class="border px-2 py-1">Published</th>
             </tr>
         </thead>
         <tbody>

--- a/tests/scraper.test.js
+++ b/tests/scraper.test.js
@@ -51,7 +51,8 @@ test('parsePrnewswire extracts articles', () => {
         </div>
     </div>`;
 
-    const items = parsePrnewswire(snippet, 'https://www.prnewswire.com/');
+    const result = parsePrnewswire(snippet, 'https://www.prnewswire.com/');
+    const items = result.items;
     assert.equal(items.length, 1);
     assert.equal(items[0].title, 'HOTEL101 PROGRESSES TOWARDS NASDAQ LISTING');
     assert.ok(items[0].description.startsWith('Hotel101 Global'));
@@ -59,4 +60,5 @@ test('parsePrnewswire extracts articles', () => {
         items[0].link,
         'https://www.prnewswire.com/news-releases/hotel101-progresses-towards-nasdaq-listing-302470771.html',
     );
+    assert.ok(items[0].published.startsWith(new Date().toISOString().split('T')[0]));
 });


### PR DESCRIPTION
## Summary
- add new `scrapedDb` module for storing scraped items
- extend scraper to capture PRNewswire article dates and return scraping rules
- store scraped items and show scraping rules on `/scrape` page
- display published date column
- initialize `scraped.db` when starting the server
- update `parsePrnewswire` test

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dc1a3cbe08331a108c218cd62cd5a