### PR TITLE
Add source persistence and deduplication

### DIFF
--- a/src/scraper.js
+++ b/src/scraper.js
@@ -1,5 +1,6 @@
 const { URL } = require('url');
 const builder = require('xmlbuilder');
+const { saveSource } = require('./scrapedDb');
 
 const RULES_PRNEWSWIRE = {
     title: '<h3> text minus <small>',
@@ -44,7 +45,9 @@ async function scrapeItems(targetUrl) {
 
     const parsed = new URL(targetUrl);
     if (/\.prnewswire\.com$/.test(parsed.hostname)) {
-        return parsePrnewswire(html, parsed);
+        const result = parsePrnewswire(html, parsed);
+        await saveSource(parsed.hostname, JSON.stringify(result.rules)).catch(() => {});
+        return result;
     }
 
     const anchorRegex = /<a\s+[^>]*href="([^"]+)"[^>]*>(.*?)<\/a>/gi;
@@ -65,6 +68,7 @@ async function scrapeItems(targetUrl) {
         description: '',
         published: '',
     };
+    await saveSource(parsed.hostname, JSON.stringify(rules)).catch(() => {});
     return { items, rules };
 }
 

--- a/src/templates/index.html
+++ b/src/templates/index.html
@@ -1,0 +1,14 @@
+<html>
+<head>
+    <title>Dealwatch</title>
+    <script src="https://cdn.tailwindcss.com"></script>
+</head>
+<body class="font-sans p-5">
+    <h1 class="text-2xl font-semibold mb-4">Dealwatch</h1>
+    <nav class="space-x-4">
+        <a href="/scrape" class="text-blue-600">Scraper</a>
+        <a href="/database" class="text-blue-600">Database</a>
+        <a href="/experiment" class="text-blue-600">Experiment</a>
+    </nav>
+</body>
+</html>

--- a/src/templates/scraper.html
+++ b/src/templates/scraper.html
@@ -11,7 +11,11 @@
         <a href="/scrape" class="text-blue-600">Scraper</a>
     </nav>
     <form>
-        <input type="text" name="url" class="border p-2 mr-2 w-80" placeholder="Website URL" value="{{url}}" />
+        <select id="sourceSelect" class="border p-2 mr-2" onchange="document.getElementById('urlInput').value=this.value">
+            <option value="">-- choose source --</option>
+            {{options}}
+        </select>
+        <input id="urlInput" type="text" name="url" class="border p-2 mr-2 w-80" placeholder="Website URL" value="{{url}}" />
         <button type="submit" class="bg-blue-500 text-white px-4 py-2">Generate RSS</button>
     </form>
     <div class="mt-4">

--- a/tests/scrapedDb.test.js
+++ b/tests/scrapedDb.test.js
@@ -1,0 +1,41 @@
+const { test } = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('fs');
+const path = require('path');
+const os = require('os');
+
+const {
+    initScrapedDB,
+    saveScrapedArticle,
+    getScrapedArticles,
+    getScrapedArticleByLink,
+    saveSource,
+    getSource,
+    getSources,
+    closeScrapedDB,
+} = require('../src/scrapedDb');
+
+test('scraped articles deduplicate on link', async () => {
+    const tmpPath = path.join(os.tmpdir(), `scraped_${Date.now()}.sqlite`);
+    initScrapedDB(tmpPath);
+    await saveScrapedArticle('http://example.com', 't1', 'd1', 'http://ex/a', null);
+    await saveScrapedArticle('http://example.com', 't1', 'd1', 'http://ex/a', null);
+    const rows = await getScrapedArticles();
+    assert.equal(rows.length, 1);
+    const row = await getScrapedArticleByLink('http://ex/a');
+    assert.ok(row);
+    closeScrapedDB();
+    fs.unlinkSync(tmpPath);
+});
+
+test('sources persisted and retrievable', async () => {
+    const tmpPath = path.join(os.tmpdir(), `sources_${Date.now()}.sqlite`);
+    initScrapedDB(tmpPath);
+    await saveSource('http://example.com/list', '{"a":1}');
+    const src = await getSource('http://example.com/list');
+    assert.equal(src.instructions, '{"a":1}');
+    const sources = await getSources();
+    assert.equal(sources.length, 1);
+    closeScrapedDB();
+    fs.unlinkSync(tmpPath);
+});


### PR DESCRIPTION
## Summary
- track scraped sources and article links in `scraped.db`
- store and deduplicate scraped articles
- persist source instructions when scraping
- add dropdown of saved sources on scraper page
- show a simple homepage linking to the scraper
- include tests for new database logic

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_b_683dc7531ae08331affa142d6ec44e97