### PR TITLE
Decouple scraper from DealWatch server

### DIFF
--- a/scraper/index.js
+++ b/scraper/index.js
@@ -1,0 +1,31 @@
+const { scrapeItems } = require('../src/scraper');
+const { initScrapedDB, saveScrapedArticle } = require('../src/scrapedDb');
+
+async function run(url) {
+  initScrapedDB();
+  const { items } = await scrapeItems(url);
+  for (const it of items) {
+    await saveScrapedArticle(
+      url,
+      it.title,
+      it.description || '',
+      it.link,
+      it.published || null,
+    ).catch(() => {});
+  }
+}
+
+const url = process.argv[2];
+if (!url) {
+  console.error('Usage: node index.js <url>');
+  process.exit(1);
+}
+
+run(url)
+  .then(() => {
+    console.log('Scraping complete');
+  })
+  .catch((err) => {
+    console.error(err);
+    process.exit(1);
+  });


### PR DESCRIPTION
## Summary
- remove integrated scraper route and database init from `server.js`
- provide standalone scraper runner under `scraper/`

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_b_683dccf1fc40833194bb865a8d1b240f